### PR TITLE
Fix identity not detected correctly for POP messages

### DIFF
--- a/chrome/content/accountcolors-utilities.js
+++ b/chrome/content/accountcolors-utilities.js
@@ -79,13 +79,13 @@ var accountColorsUtilities = {
     var identities, matches, header, ccList;
     var identityMap = new Map();
 
-    if (msgHdr.accountKey != "") {
-      return msgHdr.accountKey;
-    }
-
     msgFolder = msgHdr.folder;
     msgServer = msgFolder.server;
-    msgAccount = accountColorsUtilities.accountManager.FindAccountForServer(msgServer);
+    if (msgHdr.accountKey != "") {
+      msgAccount = accountColorsUtilities.accountManager.getAccount(msgHdr.accountKey)
+    } else {
+      msgAccount = accountColorsUtilities.accountManager.FindAccountForServer(msgServer);
+    }
 
     /* If searchAllAccounts = false, the result account / identity will only come from message's folder account */
 


### PR DESCRIPTION
Fixes https://github.com/Vigilans/accountcolors/issues/10

`msgHdr.accountKey` should not be used as terminating decision for account identity key. 

This is because accountcolors now only uses identity (`idx`) to store color preferences (and for accounts they will fall to account.defaultIdentity finally), `msgHdr.accountKey` only stores `accountx` information, result in no colors rendered.

This PR changes to only use `msgHdr.accountKey` for `msgAccount` variable detection.