### PR TITLE
Fix color picker's input box

### DIFF
--- a/chrome/content/accountcolors-options.xhtml
+++ b/chrome/content/accountcolors-options.xhtml
@@ -390,9 +390,9 @@
             <html:input type="range" id="accountcolors-picker-b-scale" min="0" max="255" oninput="accountColorsOptions.pickerRGBScaleChange()" />
           </column>
           <column>
-            <textbox id="accountcolors-picker-r-value" type="number" min="0" max="255" onchange="accountColorsOptions.pickerRGBValueChange()" oninput="accountColorsOptions.pickerRGBValueChange()" />
-            <textbox id="accountcolors-picker-g-value" type="number" min="0" max="255" onchange="accountColorsOptions.pickerRGBValueChange()" oninput="accountColorsOptions.pickerRGBValueChange()" />
-            <textbox id="accountcolors-picker-b-value" type="number" min="0" max="255" onchange="accountColorsOptions.pickerRGBValueChange()" oninput="accountColorsOptions.pickerRGBValueChange()" />
+            <html:input type="number" id="accountcolors-picker-r-value" min="0" max="255" onchange="accountColorsOptions.pickerRGBValueChange()" oninput="accountColorsOptions.pickerRGBValueChange()" />
+            <html:input type="number" id="accountcolors-picker-g-value" min="0" max="255" onchange="accountColorsOptions.pickerRGBValueChange()" oninput="accountColorsOptions.pickerRGBValueChange()" />
+            <html:input type="number" id="accountcolors-picker-b-value" min="0" max="255" onchange="accountColorsOptions.pickerRGBValueChange()" oninput="accountColorsOptions.pickerRGBValueChange()" />
           </column>
         </columns>
       </grid>
@@ -415,9 +415,9 @@
             <html:input type="range" id="accountcolors-picker-v-scale" min="0" max="100" oninput="accountColorsOptions.pickerHSVScaleChange()" />
           </column>
           <column>
-            <textbox id="accountcolors-picker-h-value" type="number" min="0" max="360" onchange="accountColorsOptions.pickerHSVValueChange()" oninput="accountColorsOptions.pickerHSVValueChange()" />
-            <textbox id="accountcolors-picker-s-value" type="number" min="0" max="100" onchange="accountColorsOptions.pickerHSVValueChange()" oninput="accountColorsOptions.pickerHSVValueChange()" />
-            <textbox id="accountcolors-picker-v-value" type="number" min="0" max="100" onchange="accountColorsOptions.pickerHSVValueChange()" oninput="accountColorsOptions.pickerHSVValueChange()" />
+            <html:input type="number" id="accountcolors-picker-h-value" min="0" max="360" onchange="accountColorsOptions.pickerHSVValueChange()" oninput="accountColorsOptions.pickerHSVValueChange()" />
+            <html:input type="number" id="accountcolors-picker-s-value" min="0" max="100" onchange="accountColorsOptions.pickerHSVValueChange()" oninput="accountColorsOptions.pickerHSVValueChange()" />
+            <html:input type="number" id="accountcolors-picker-v-value" min="0" max="100" onchange="accountColorsOptions.pickerHSVValueChange()" oninput="accountColorsOptions.pickerHSVValueChange()" />
           </column>
         </columns>
       </grid>

--- a/chrome/skin/accountcolors-options.css
+++ b/chrome/skin/accountcolors-options.css
@@ -287,12 +287,12 @@ separator.section {
   background-color: #f0f0f0;
 }
 
-#accountcolors-picker-r-value,
-#accountcolors-picker-g-value,
-#accountcolors-picker-b-value,
-#accountcolors-picker-h-value,
-#accountcolors-picker-s-value,
-#accountcolors-picker-v-value {
+input[type="number"]#accountcolors-picker-r-value,
+input[type="number"]#accountcolors-picker-g-value,
+input[type="number"]#accountcolors-picker-b-value,
+input[type="number"]#accountcolors-picker-h-value,
+input[type="number"]#accountcolors-picker-s-value,
+input[type="number"]#accountcolors-picker-v-value {
   width: 40px;
   margin-left: 6px;
   margin-right: 6px;


### PR DESCRIPTION
This PR replaces `<textbox>` element with `<html:input>`, to make color picker's input box visible. `<textbox>` is an older XUL element that's being phased out in favor of HTML elements in newer versions of Thunderbird.

Fixes https://github.com/gazhay/accountcolors/issues/7