### PR TITLE
Enhance account color picker

### DIFF
--- a/chrome/content/accountcolors-options.js
+++ b/chrome/content/accountcolors-options.js
@@ -1541,7 +1541,7 @@ var accountColorsOptions = {
   },
 
   updateFontColor: function (index) {
-    var i, length;
+    var i, length, color;
 
     if (accountColorsOptions.prefs.getBoolPref("picker-autobkgd")) {
       accountColorsOptions.pickerSetColor("accountcolors-bkgdpicker" + index, accountColorsOptions.autoBkgdColor(accountColorsOptions.pickerGetColor("accountcolors-fontpicker" + index)));
@@ -1573,7 +1573,7 @@ var accountColorsOptions = {
   },
 
   updateBkgdColor: function (index) {
-    var i, length;
+    var i, length, color;
 
     document.getElementById("accountcolors-accountname" + index).style.backgroundColor = accountColorsOptions.pickerGetColor("accountcolors-bkgdpicker" + index);
 

--- a/chrome/content/accountcolors-options.js
+++ b/chrome/content/accountcolors-options.js
@@ -94,8 +94,13 @@ var accountColorsOptions = {
 
     /* Add listeners for click on font/background palette panels */
 
-    document.getElementById("accountcolors-picker-fontpalette-panel").addEventListener("click", accountColorsOptions.pickerPaletteChange, false);
-    document.getElementById("accountcolors-picker-bkgdpalette-panel").addEventListener("click", accountColorsOptions.pickerPaletteChange, false);
+    if (accountColorsUtilities.thunderbirdVersion.major > 102) {
+      document.getElementById("accountcolors-picker-fontpalette-native").addEventListener("input", accountColorsOptions.pickerPaletteChange, false);
+      document.getElementById("accountcolors-picker-bkgdpalette-native").addEventListener("input", accountColorsOptions.pickerPaletteChange, false);
+    } else {
+      document.getElementById("accountcolors-picker-fontpalette-panel").addEventListener("click", accountColorsOptions.pickerPaletteChange, false);
+      document.getElementById("accountcolors-picker-bkgdpalette-panel").addEventListener("click", accountColorsOptions.pickerPaletteChange, false);
+    }
 
     /* Color scheme for dialogs page */
     document.getElementById("accountcolors-options").style.setProperty("color-scheme", accountColorsOptions.theme.properties.color_scheme);
@@ -1648,32 +1653,53 @@ var accountColorsOptions = {
       document.getElementById("accountcolors-picker-fonttitle").hidden = false;
       document.getElementById("accountcolors-picker-bkgdtitle").hidden = true;
 
-      document.getElementById("accountcolors-picker-fontpalette").hidden = false;
-      document.getElementById("accountcolors-picker-bkgdpalette").hidden = true;
+      if (accountColorsUtilities.thunderbirdVersion.major > 102) {
+        document.getElementById("accountcolors-picker-fontpalette").hidden = true;
+        document.getElementById("accountcolors-picker-bkgdpalette").hidden = true;
+        document.getElementById("accountcolors-picker-fontpalette-native").hidden = false;
+        document.getElementById("accountcolors-picker-bkgdpalette-native").hidden = true;
+
+        document.getElementById("accountcolors-picker-fontpalette-native").value = "#" + hexstr;
+      } else {
+        document.getElementById("accountcolors-picker-fontpalette").hidden = false;
+        document.getElementById("accountcolors-picker-bkgdpalette").hidden = true;
+        document.getElementById("accountcolors-picker-fontpalette-native").hidden = true;
+        document.getElementById("accountcolors-picker-bkgdpalette-native").hidden = true;
+
+        element = document
+          .getElementById("accountcolors-picker-fontpalette-panel")
+          .getElementsByAttribute("color", "#" + hexstr)
+          .item(0);
+        if (element != null) document.getElementById("accountcolors-picker-fontpalette").children[0].style.setProperty("background-color", "#" + hexstr, "");
+        else document.getElementById("accountcolors-picker-fontpalette").children[0].style.setProperty("background-color", "#E1E1E1");
+      }
 
       document.getElementById("accountcolors-picker-autobkgd-box").hidden = false;
-
-      element = document
-        .getElementById("accountcolors-picker-fontpalette-panel")
-        .getElementsByAttribute("color", "#" + hexstr)
-        .item(0);
-      if (element != null) document.getElementById("accountcolors-picker-fontpalette").children[0].style.setProperty("background-color", "#" + hexstr, "");
-      else document.getElementById("accountcolors-picker-fontpalette").children[0].style.setProperty("background-color", "#E1E1E1");
     } else {
       document.getElementById("accountcolors-picker-fonttitle").hidden = true;
       document.getElementById("accountcolors-picker-bkgdtitle").hidden = false;
 
-      document.getElementById("accountcolors-picker-fontpalette").hidden = true;
-      document.getElementById("accountcolors-picker-bkgdpalette").hidden = false;
+      if (accountColorsUtilities.thunderbirdVersion.major > 102) {
+        document.getElementById("accountcolors-picker-fontpalette").hidden = true;
+        document.getElementById("accountcolors-picker-bkgdpalette").hidden = true;
+        document.getElementById("accountcolors-picker-fontpalette-native").hidden = true;
+        document.getElementById("accountcolors-picker-bkgdpalette-native").hidden = false;
 
+        document.getElementById("accountcolors-picker-bkgdpalette-native").value = "#" + hexstr;
+      } else {
+        document.getElementById("accountcolors-picker-fontpalette").hidden = true;
+        document.getElementById("accountcolors-picker-bkgdpalette").hidden = false;
+        document.getElementById("accountcolors-picker-fontpalette-native").hidden = true;
+        document.getElementById("accountcolors-picker-bkgdpalette-native").hidden = true;
+
+        element = document
+          .getElementById("accountcolors-picker-bkgdpalette-panel")
+          .getElementsByAttribute("color", "#" + hexstr)
+          .item(0);
+        if (element != null) document.getElementById("accountcolors-picker-bkgdpalette").children[0].style.setProperty("background-color", "#" + hexstr, "");
+        else document.getElementById("accountcolors-picker-bkgdpalette").children[0].style.setProperty("background-color", "#E1E1E1");
+      }
       document.getElementById("accountcolors-picker-autobkgd-box").hidden = true;
-
-      element = document
-        .getElementById("accountcolors-picker-bkgdpalette-panel")
-        .getElementsByAttribute("color", "#" + hexstr)
-        .item(0);
-      if (element != null) document.getElementById("accountcolors-picker-bkgdpalette").children[0].style.setProperty("background-color", "#" + hexstr, "");
-      else document.getElementById("accountcolors-picker-bkgdpalette").children[0].style.setProperty("background-color", "#E1E1E1");
     }
 
     document.getElementById("accountcolors-picker-autobkgd").checked = accountColorsOptions.prefs.getBoolPref("picker-autobkgd");
@@ -1840,18 +1866,26 @@ var accountColorsOptions = {
 
     pickerbutton = accountColorsOptions.pickerButton;
 
-    if (pickerbutton.id.indexOf("font") >= 0) {
-      hexstr = event.target.getAttribute("color").substr(1);
-
-      document.getElementById("accountcolors-picker-fontpalette").children[0].style.setProperty("background-color", "#" + hexstr, "");
-
-      document.getElementById("accountcolors-picker-fontpalette-panel").hidePopup();
+    if (accountColorsUtilities.thunderbirdVersion.major > 102) {
+      if (pickerbutton.id.indexOf("font") >= 0) {
+        hexstr = event.target.value.substr(1);
+      } else {
+        hexstr = event.target.value.substr(1);
+      }
     } else {
-      hexstr = event.target.getAttribute("color").substr(1);
+      if (pickerbutton.id.indexOf("font") >= 0) {
+        hexstr = event.target.getAttribute("color").substr(1);
 
-      document.getElementById("accountcolors-picker-bkgdpalette").children[0].style.setProperty("background-color", "#" + hexstr, "");
+        document.getElementById("accountcolors-picker-fontpalette").children[0].style.setProperty("background-color", "#" + hexstr, "");
 
-      document.getElementById("accountcolors-picker-bkgdpalette-panel").hidePopup();
+        document.getElementById("accountcolors-picker-fontpalette-panel").hidePopup();
+      } else {
+        hexstr = event.target.getAttribute("color").substr(1);
+
+        document.getElementById("accountcolors-picker-bkgdpalette").children[0].style.setProperty("background-color", "#" + hexstr, "");
+
+        document.getElementById("accountcolors-picker-bkgdpalette-panel").hidePopup();
+      }
     }
 
     value = parseInt(hexstr, 16);

--- a/chrome/content/accountcolors-options.js
+++ b/chrome/content/accountcolors-options.js
@@ -1594,6 +1594,31 @@ var accountColorsOptions = {
     }
   },
 
+  /* Reset background color to account's color (first identity's color) */
+  resetBkgdColor: function (index) {
+    var type = document.getElementById("accountcolors-accountidbox" + index).getAttribute("ac-accountidtype");
+    var baseIndex = index;
+    while (baseIndex >= 0 && document.getElementById("accountcolors-accountidbox" + baseIndex).getAttribute("ac-accountidtype") == "id") baseIndex--;
+
+    var color = accountColorsOptions.pickerGetColor("accountcolors-bkgdpicker" + baseIndex);
+    color = accountColorsOptions.pickerSetColor("accountcolors-bkgdpicker" + index, color);
+    document.getElementById("accountcolors-accountname" + index).style.backgroundColor = color;
+    if (type != "account") document.getElementById("accountcolors-identityname" + index).style.backgroundColor = color;
+  },
+
+  /* Reset font color to account's color (first identity's color) */
+  resetFontColor: function (index) {
+    var type = document.getElementById("accountcolors-accountidbox" + index).getAttribute("ac-accountidtype");
+    var baseIndex = index;
+    while (baseIndex >= 0 && document.getElementById("accountcolors-accountidbox" + baseIndex).getAttribute("ac-accountidtype") == "id") baseIndex--;
+
+    var color = accountColorsOptions.pickerGetColor("accountcolors-fontpicker" + baseIndex);
+    color = accountColorsOptions.pickerSetColor("accountcolors-fontpicker" + index, color);
+    document.getElementById("accountcolors-accountname" + index).style.color = color;
+    if (type != "account") document.getElementById("accountcolors-identityname" + index).style.color = color;
+  },
+
+
   /********************************************************************/
 
   /* Color picker functions */
@@ -1976,6 +2001,23 @@ var accountColorsOptions = {
 
     if (pickerbutton.id.indexOf("font") >= 0) accountColorsOptions.updateFontColor(Number(pickerbutton.id.substr(24)));
     else accountColorsOptions.updateBkgdColor(Number(pickerbutton.id.substr(24)));
+
+    document.getElementById("accountcolors-picker-panel").hidePopup();
+
+    window.removeEventListener("keypress", accountColorsOptions.pickerReturn, true);
+  },
+
+  pickerReset: function () {
+    var pickerbutton, hexstr;
+
+    pickerbutton = accountColorsOptions.pickerButton;
+
+    hexstr = document.getElementById("accountcolors-picker-hexstr").value;
+
+    accountColorsOptions.pickerSetColor(pickerbutton.id, "#" + hexstr);
+
+    if (pickerbutton.id.indexOf("font") >= 0) accountColorsOptions.resetFontColor(Number(pickerbutton.id.substr(24)));
+    else accountColorsOptions.resetBkgdColor(Number(pickerbutton.id.substr(24)));
 
     document.getElementById("accountcolors-picker-panel").hidePopup();
 

--- a/chrome/content/accountcolors-options.xhtml
+++ b/chrome/content/accountcolors-options.xhtml
@@ -368,6 +368,8 @@
       <hbox id="accountcolors-picker-overview">
         <button id="accountcolors-picker-fontpalette" class="accountcolors-picker" oncommand="accountColorsOptions.pickerPaletteOpen(this);" />
         <button id="accountcolors-picker-bkgdpalette" class="accountcolors-picker" oncommand="accountColorsOptions.pickerPaletteOpen(this);" />
+        <html:input type="color" id="accountcolors-picker-fontpalette-native" class="accountcolors-picker" oninput="accountColorsOptions.pickerHexStrChange()" />
+        <html:input type="color" id="accountcolors-picker-bkgdpalette-native" class="accountcolors-picker" oninput="accountColorsOptions.pickerHexStrChange()" />
         <label id="accountcolors-picker-sample" flex="1" value="&accountcolors.picker.sample;" />
         <html:input type="string" id="accountcolors-picker-hexstr" oninput="accountColorsOptions.pickerHexStrChange()" />
       </hbox>

--- a/chrome/content/accountcolors-options.xhtml
+++ b/chrome/content/accountcolors-options.xhtml
@@ -369,7 +369,7 @@
         <button id="accountcolors-picker-fontpalette" class="accountcolors-picker" oncommand="accountColorsOptions.pickerPaletteOpen(this);" />
         <button id="accountcolors-picker-bkgdpalette" class="accountcolors-picker" oncommand="accountColorsOptions.pickerPaletteOpen(this);" />
         <label id="accountcolors-picker-sample" flex="1" value="&accountcolors.picker.sample;" />
-        <textbox id="accountcolors-picker-hexstr" oninput="accountColorsOptions.pickerHexStrChange()" />
+        <html:input type="string" id="accountcolors-picker-hexstr" oninput="accountColorsOptions.pickerHexStrChange()" />
       </hbox>
       <separator id="accountcolors-picker-separator-1" class="groove" />
       <grid>

--- a/chrome/content/accountcolors-options.xhtml
+++ b/chrome/content/accountcolors-options.xhtml
@@ -435,6 +435,7 @@
       <separator id="accountcolors-picker-separator-4" class="groove" />
       <hbox id="accountcolors-picker-buttons" pack="center">
         <button id="accountcolors-picker-okay" label="&accountcolors.picker.okay;" default="true" oncommand="accountColorsOptions.pickerOkay();" />
+        <button id="accountcolors-picker-reset" label="&accountcolors.account.reset;" oncommand="accountColorsOptions.pickerReset();" />
         <button id="accountcolors-picker-cancel" label="&accountcolors.picker.cancel;" oncommand="accountColorsOptions.pickerClose();" />
       </hbox>
     </vbox>

--- a/chrome/locale/de/accountcolors.dtd
+++ b/chrome/locale/de/accountcolors.dtd
@@ -13,6 +13,7 @@
 <!ENTITY accountcolors.account.identity "Identität">
 <!ENTITY accountcolors.account.font "Text">
 <!ENTITY accountcolors.account.bkgd "Hintergrund">
+<!ENTITY accountcolors.account.reset "Zurücksetzen">
 <!ENTITY accountcolors.folder.setfontstyle "Schriftstil für Konten-Bezeichnung:">
 <!ENTITY accountcolors.folder.setfontsize "Schriftgröße für Konten-Bezeichnung:">
 <!ENTITY accountcolors.folder.colorfont "Konten-Bezeichnung kolorieren">

--- a/chrome/locale/en-US/accountcolors.dtd
+++ b/chrome/locale/en-US/accountcolors.dtd
@@ -17,6 +17,7 @@
 <!ENTITY accountcolors.account.identity         "Identity">
 <!ENTITY accountcolors.account.font             "Font">
 <!ENTITY accountcolors.account.bkgd             "Bkgd">
+<!ENTITY accountcolors.account.reset            "Reset">
 
 <!ENTITY accountcolors.folder.setfontstyle      "Account Font Style">
 <!ENTITY accountcolors.folder.setfontsize       "Account Font Size">

--- a/chrome/locale/es-ES/accountcolors.dtd
+++ b/chrome/locale/es-ES/accountcolors.dtd
@@ -13,6 +13,7 @@
 <!ENTITY accountcolors.account.identity "Identidad">
 <!ENTITY accountcolors.account.font "Fuente">
 <!ENTITY accountcolors.account.bkgd "Bkgd">
+<!ENTITY accountcolors.account.reset "Restablecer">
 <!ENTITY accountcolors.folder.setfontstyle "Estilo de Fuente de la Cuenta">
 <!ENTITY accountcolors.folder.setfontsize "Tamaño de Fuente de la Cuenta">
 <!ENTITY accountcolors.folder.colorfont "Color de Fuente de la Cuenta">

--- a/chrome/locale/fi-FI/accountcolors.dtd
+++ b/chrome/locale/fi-FI/accountcolors.dtd
@@ -13,6 +13,7 @@
 <!ENTITY accountcolors.account.identity "Identiteetti">
 <!ENTITY accountcolors.account.font "Fontti">
 <!ENTITY accountcolors.account.bkgd "Tausta">
+<!ENTITY accountcolors.account.reset "Palauta">
 <!ENTITY accountcolors.folder.setfontstyle "Tilin fonttityyli">
 <!ENTITY accountcolors.folder.setfontsize "Tilin fontin koko">
 <!ENTITY accountcolors.folder.colorfont "Väritä tilin fontti">

--- a/chrome/locale/fi/accountcolors.dtd
+++ b/chrome/locale/fi/accountcolors.dtd
@@ -13,6 +13,7 @@
 <!ENTITY accountcolors.account.identity "Identiteetti">
 <!ENTITY accountcolors.account.font "Fontti">
 <!ENTITY accountcolors.account.bkgd "Tausta">
+<!ENTITY accountcolors.account.reset "Palauta">
 <!ENTITY accountcolors.folder.setfontstyle "Tilin fonttityyli">
 <!ENTITY accountcolors.folder.setfontsize "Tilin fontin koko">
 <!ENTITY accountcolors.folder.colorfont "Väritä tilin fontti">

--- a/chrome/locale/fr/accountcolors.dtd
+++ b/chrome/locale/fr/accountcolors.dtd
@@ -13,6 +13,7 @@
 <!ENTITY accountcolors.account.identity "Identité">
 <!ENTITY accountcolors.account.font "Police">
 <!ENTITY accountcolors.account.bkgd "Fond">
+<!ENTITY accountcolors.account.reset "Réinitialiser">
 <!ENTITY accountcolors.folder.setfontstyle "Style de police pour le compte">
 <!ENTITY accountcolors.folder.setfontsize "Taille de la police du compte">
 <!ENTITY accountcolors.folder.colorfont "Couleur de la police des comptes">

--- a/chrome/locale/it/accountcolors.dtd
+++ b/chrome/locale/it/accountcolors.dtd
@@ -13,6 +13,7 @@
 <!ENTITY accountcolors.account.identity "Identità">
 <!ENTITY accountcolors.account.font "Font">
 <!ENTITY accountcolors.account.bkgd "Sfondo">
+<!ENTITY accountcolors.account.reset "Reimposta">
 <!ENTITY accountcolors.folder.setfontstyle "Stile font Account">
 <!ENTITY accountcolors.folder.setfontsize "Dimensioni font Account">
 <!ENTITY accountcolors.folder.colorfont "Colora font Account">

--- a/chrome/locale/pt-BR/accountcolors.dtd
+++ b/chrome/locale/pt-BR/accountcolors.dtd
@@ -13,6 +13,7 @@
 <!ENTITY accountcolors.account.identity "Perfil">
 <!ENTITY accountcolors.account.font "Fonte">
 <!ENTITY accountcolors.account.bkgd "Fundo">
+<!ENTITY accountcolors.account.reset "Redefinir">
 <!ENTITY accountcolors.folder.setfontstyle "Estilo da Fonte da Conta">
 <!ENTITY accountcolors.folder.setfontsize "Tamanho da Fonte da Conta">
 <!ENTITY accountcolors.folder.colorfont "Cor da Fonte da Conta">

--- a/chrome/locale/sv-SE/accountcolors.dtd
+++ b/chrome/locale/sv-SE/accountcolors.dtd
@@ -13,6 +13,7 @@
 <!ENTITY accountcolors.account.identity "Identitet">
 <!ENTITY accountcolors.account.font "Typsnitt">
 <!ENTITY accountcolors.account.bkgd "Bkgr">
+<!ENTITY accountcolors.account.reset "Återställ">
 <!ENTITY accountcolors.folder.setfontstyle "Teckenstil för konto">
 <!ENTITY accountcolors.folder.setfontsize "Teckenstorlek för konto">
 <!ENTITY accountcolors.folder.colorfont "Färga kontons typsnitt">

--- a/chrome/locale/zh-CN/accountcolors.dtd
+++ b/chrome/locale/zh-CN/accountcolors.dtd
@@ -13,6 +13,7 @@
 <!ENTITY accountcolors.account.identity "身份">
 <!ENTITY accountcolors.account.font "字体">
 <!ENTITY accountcolors.account.bkgd "背景">
+<!ENTITY accountcolors.account.reset "重置">
 <!ENTITY accountcolors.folder.setfontstyle "帐户字体样式">
 <!ENTITY accountcolors.folder.setfontsize "帐户字体大小">
 <!ENTITY accountcolors.folder.colorfont "帐户字体颜色">

--- a/chrome/skin/accountcolors-options.css
+++ b/chrome/skin/accountcolors-options.css
@@ -146,6 +146,7 @@
 .accountcolors-picker {
   min-width: 40px;
   width: 40px;
+  max-height: 22.5px;
   margin: 0px 3px;
   padding: 2px;
 }


### PR DESCRIPTION
This pull request introduces a "Reset" feature for account font and background colors in the options dialog, improves compatibility with Thunderbird versions above 102 by using native color pickers, and updates the UI and localization files accordingly. The most important changes are grouped below:

**New Features:**

* Added "Reset" button to the color picker dialog, allowing users to revert font and background colors to the account's default (first identity's color). New `resetFontColor` and `resetBkgdColor` functions handle the logic. (`chrome/content/accountcolors-options.js`, `chrome/content/accountcolors-options.xhtml`) [[1]](diffhunk://#diff-71f0b6f21f0acfecbebde7bd458231c3c071e28c202a744773f39e6391562e35R1602-R1626) [[2]](diffhunk://#diff-71f0b6f21f0acfecbebde7bd458231c3c071e28c202a744773f39e6391562e35R2044-R2060) [[3]](diffhunk://#diff-640c719e4ab2089ca9e9c312d9d0fef3c077561cee075ce7565684a699ca45d3R440)
* Added "Reset" label to all supported locales for the new button. (`chrome/locale/*/accountcolors.dtd`) [[1]](diffhunk://#diff-c95e0a805eea065e9d43d28ab28024be169d69ebed91b03cb24326426900c30bR20) [[2]](diffhunk://#diff-30108d9977b8a1e56cc251259020cd32a76809c4bb63abdd017e6823709d27daR16) [[3]](diffhunk://#diff-6628928c408113283e450192ce47364d3f2c09b7db0a55d607cd5d07a51d63a9R16) [[4]](diffhunk://#diff-f6cd03cf152d77691d09b42d509c64f88b5eeb8cee89e8fbf9af0c3568cd3762R16) [[5]](diffhunk://#diff-997cf47956731a7c947b539a6f0190f8cce34b5bcd1e1cc6ba264c43b0140b0bR16) [[6]](diffhunk://#diff-6812aec0c0ad12f057ee4b25388df618ca8db500c246ae14fd70e560dc3acd75R16) [[7]](diffhunk://#diff-483f0ec471c60622a2512dd625e238d02fa6b9d5937e78655df19300bb97b851R16) [[8]](diffhunk://#diff-2fbc55a9a183700554d0d1b4a1bcda85c0e746f20345096cc4b5d1105f72b996R16) [[9]](diffhunk://#diff-284dd92e8bd12771d857fee5d3a68d5795ee2998b8950307ee31154d754a7341R16)

**Thunderbird Compatibility:**

* Introduced conditional logic to use native `<input type="color">` elements for color picking on Thunderbird versions > 102, improving integration and user experience. (`chrome/content/accountcolors-options.js`, `chrome/content/accountcolors-options.xhtml`) [[1]](diffhunk://#diff-71f0b6f21f0acfecbebde7bd458231c3c071e28c202a744773f39e6391562e35R97-R103) [[2]](diffhunk://#diff-640c719e4ab2089ca9e9c312d9d0fef3c077561cee075ce7565684a699ca45d3R371-R374)
* Adjusted event handling and palette visibility logic to support both legacy and native color pickers depending on Thunderbird version. (`chrome/content/accountcolors-options.js`) [[1]](diffhunk://#diff-71f0b6f21f0acfecbebde7bd458231c3c071e28c202a744773f39e6391562e35L1626-R1693) [[2]](diffhunk://#diff-71f0b6f21f0acfecbebde7bd458231c3c071e28c202a744773f39e6391562e35R1869-R1875) [[3]](diffhunk://#diff-71f0b6f21f0acfecbebde7bd458231c3c071e28c202a744773f39e6391562e35R1889)

**Fixes:**

* Fix apply color to all identities not working
* Changed the hex string input in the color picker dialog from `<textbox>` to `<input type="string">` for improved compatibility. (`chrome/content/accountcolors-options.xhtml`)

Fixes #34 