### PR TITLE
Use thunderbird 128+‘s native account color as default fallback

### DIFF
--- a/chrome/content/accountcolors-options.js
+++ b/chrome/content/accountcolors-options.js
@@ -147,13 +147,13 @@ var accountColorsOptions = {
         document.getElementById("accountcolors-accountname" + index).value = account.incomingServer.prettyName;
 
         try {
-          color = accountColorsOptions.pickerSetColor("accountcolors-fontpicker" + index, accountColorsOptions.prefs.getCharPref(account.key + "-fontcolor"));
+          color = accountColorsOptions.pickerSetColor("accountcolors-fontpicker" + index, accountColorsUtilities.fontColorPref(account.key));
           document.getElementById("accountcolors-accountname" + index).style.color = color;
         } catch (e) {
           if (account.incomingServer == accountColorsOptions.accountManager.localFoldersServer) {
             try {
               /* compatibility with Version 3.0 */
-              color = accountColorsOptions.pickerSetColor("accountcolors-fontpicker" + index, accountColorsOptions.prefs.getCharPref("idLF" + "-fontcolor"));
+              color = accountColorsOptions.pickerSetColor("accountcolors-fontpicker" + index, accountColorsUtilities.fontColorPref("idLF"));
               document.getElementById("accountcolors-accountname" + index).style.color = color;
             } catch (e) {
               color = accountColorsOptions.pickerSetColor("accountcolors-fontpicker" + index, "");
@@ -166,13 +166,13 @@ var accountColorsOptions = {
         }
 
         try {
-          color = accountColorsOptions.pickerSetColor("accountcolors-bkgdpicker" + index, accountColorsOptions.prefs.getCharPref(account.key + "-bkgdcolor"));
+          color = accountColorsOptions.pickerSetColor("accountcolors-bkgdpicker" + index, accountColorsUtilities.bkgdColorPref(account.key));
           document.getElementById("accountcolors-accountname" + index).style.backgroundColor = color;
         } catch (e) {
           if (account.incomingServer == accountColorsOptions.accountManager.localFoldersServer) {
             try {
               /* compatibility with Version 3.0 */
-              color = accountColorsOptions.pickerSetColor("accountcolors-bkgdpicker" + index, accountColorsOptions.prefs.getCharPref("idLF" + "-bkgdcolor"));
+              color = accountColorsOptions.pickerSetColor("accountcolors-bkgdpicker" + index, accountColorsUtilities.bkgdColorPref("idLF"));
               document.getElementById("accountcolors-accountname" + index).style.backgroundColor = color;
             } catch (e) {
               color = accountColorsOptions.pickerSetColor("accountcolors-bkgdpicker" + index, "");
@@ -214,13 +214,13 @@ var accountColorsOptions = {
           document.getElementById("accountcolors-identityname" + index).value = identity.identityName;
 
           try {
-            color = accountColorsOptions.pickerSetColor("accountcolors-fontpicker" + index, accountColorsOptions.prefs.getCharPref(identity.key + "-fontcolor"));
+            color = accountColorsOptions.pickerSetColor("accountcolors-fontpicker" + index, accountColorsUtilities.fontColorPref(identity.key));
             document.getElementById("accountcolors-accountname" + index).style.color = color;
             document.getElementById("accountcolors-identityname" + index).style.color = color;
           } catch (e) {
             try {
               /* compatibility with Version 2.0 */
-              color = accountColorsOptions.pickerSetColor("accountcolors-fontpicker" + index, accountColorsOptions.prefs.getCharPref(account.key + "-fontcolor"));
+              color = accountColorsOptions.pickerSetColor("accountcolors-fontpicker" + index, accountColorsUtilities.fontColorPref(account.key));
               document.getElementById("accountcolors-accountname" + index).style.color = color;
               document.getElementById("accountcolors-identityname" + index).style.color = color;
             } catch (e) {
@@ -232,13 +232,13 @@ var accountColorsOptions = {
           }
 
           try {
-            color = accountColorsOptions.pickerSetColor("accountcolors-bkgdpicker" + index, accountColorsOptions.prefs.getCharPref(identity.key + "-bkgdcolor"));
+            color = accountColorsOptions.pickerSetColor("accountcolors-bkgdpicker" + index, accountColorsUtilities.bkgdColorPref(identity.key));
             document.getElementById("accountcolors-accountname" + index).style.backgroundColor = color;
             document.getElementById("accountcolors-identityname" + index).style.backgroundColor = color;
           } catch (e) {
             try {
               /* compatibility with Version 2.0 */
-              color = accountColorsOptions.pickerSetColor("accountcolors-bkgdpicker" + index, accountColorsOptions.prefs.getCharPref(account.key + "-bkgdcolor"));
+              color = accountColorsOptions.pickerSetColor("accountcolors-bkgdpicker" + index, accountColorsUtilities.bkgdColorPref(account.key));
               document.getElementById("accountcolors-accountname" + index).style.backgroundColor = color;
               document.getElementById("accountcolors-identityname" + index).style.backgroundColor = color;
             } catch (e) {
@@ -1605,10 +1605,31 @@ var accountColorsOptions = {
     var baseIndex = index;
     while (baseIndex >= 0 && document.getElementById("accountcolors-accountidbox" + baseIndex).getAttribute("ac-accountidtype") == "id") baseIndex--;
 
-    var color = accountColorsOptions.pickerGetColor("accountcolors-bkgdpicker" + baseIndex);
-    color = accountColorsOptions.pickerSetColor("accountcolors-bkgdpicker" + index, color);
-    document.getElementById("accountcolors-accountname" + index).style.backgroundColor = color;
-    if (type != "account") document.getElementById("accountcolors-identityname" + index).style.backgroundColor = color;
+    var color;
+    if (baseIndex != index) { // Reset identity's color to account's color
+      color = accountColorsOptions.pickerGetColor("accountcolors-bkgdpicker" + baseIndex);
+      color = accountColorsOptions.pickerSetColor("accountcolors-bkgdpicker" + index, color);
+      document.getElementById("accountcolors-identityname" + index).style.backgroundColor = color;
+    } else if (accountColorsUtilities.thunderbirdVersion.major >= 128) { // Reset account's color to thunderbird 128+'s account color
+      var accountidkey = document.getElementById("accountcolors-accountidbox" + index).getAttribute("ac-accountidkey");
+      var identity, server, account;
+      if (accountidkey.startsWith("id")) {
+        identity = accountColorsUtilities.accountManager.getIdentity(accountidkey);
+        server = accountColorsUtilities.accountManager.getServersForIdentity(identity)[0];
+        account = accountColorsUtilities.accountManager.findAccountForServer(server);
+      } else {
+        account = accountColorsUtilities.accountManager.getAccount(accountidkey);
+        server = account.incomingServer;
+      }
+      color = FolderTreeProperties.getColor(server.rootFolder.URI) || "";
+      color = accountColorsOptions.pickerSetColor("accountcolors-bkgdpicker" + index, color);
+      document.getElementById("accountcolors-accountname" + index).style.backgroundColor = color;
+      document.getElementById("accountcolors-identityname" + index).style.backgroundColor = color;
+    } else {
+      accountColorsOptions.pickerSetColor("accountcolors-bkgdpicker" + index, "");
+      document.getElementById("accountcolors-accountname" + index).style.backgroundColor = "";
+      document.getElementById("accountcolors-identityname" + index).style.backgroundColor = "";
+    }
   },
 
   /* Reset font color to account's color (first identity's color) */

--- a/chrome/content/accountcolors-utilities.js
+++ b/chrome/content/accountcolors-utilities.js
@@ -26,6 +26,12 @@ function getThunderbirdVersion() {
   }
 }
 
+if (getThunderbirdVersion().major >= 128) {
+  var { FolderTreeProperties } = ChromeUtils.importESModule(
+    "resource:///modules/FolderTreeProperties.sys.mjs"
+  );
+}
+
 var accountColorsUtilities = {
   thunderbirdVersion: getThunderbirdVersion(),
 
@@ -288,11 +294,33 @@ var accountColorsUtilities = {
 
   bkgdColorPref: function (accountidkey) {
     var bkgdcolor;
+    var account, identity, server;
 
     try {
       bkgdcolor = accountColorsUtilities.prefs.getCharPref(accountidkey + "-bkgdcolor");
     } catch (e) {
       bkgdcolor = "";
+    }
+
+    if (!bkgdcolor) {
+      if (accountidkey.startsWith("id")) {
+        identity = accountColorsUtilities.accountManager.getIdentity(accountidkey);
+        server = accountColorsUtilities.accountManager.getServersForIdentity(identity)[0];
+        account = accountColorsUtilities.accountManager.findAccountForServer(server);
+        try { // Try to get bkgdcolor from account when identity color not set
+          bkgdcolor = accountColorsUtilities.prefs.getCharPref(account.key + "-bkgdcolor");
+        } catch (e) {
+          bkgdcolor = "";
+        }
+      } else {
+        account = accountColorsUtilities.accountManager.getAccount(accountidkey);
+        server = account.incomingServer;
+      }
+
+      // Try use thunderbird 128+ feature to get bkgdcolor as fallback
+      if (!bkgdcolor && accountColorsUtilities.thunderbirdVersion.major >= 128) {
+        bkgdcolor = FolderTreeProperties.getColor(server.rootFolder.URI);
+      }
     }
 
     return bkgdcolor;


### PR DESCRIPTION
This pull request refactors how background and font colors are retrieved and set for accounts and identities, improving compatibility with Thunderbird 128+ and enhancing fallback logic. The changes centralize color preference retrieval in utility functions and introduce support for Thunderbird's new account color property.

**Color preference retrieval and fallback improvements:**

* Replaced direct preference access in `accountcolors-options.js` with calls to new utility functions (`fontColorPref` and `bkgdColorPref`) from `accountColorsUtilities`, improving code maintainability and encapsulation. [[1]](diffhunk://#diff-71f0b6f21f0acfecbebde7bd458231c3c071e28c202a744773f39e6391562e35L150-R156) [[2]](diffhunk://#diff-71f0b6f21f0acfecbebde7bd458231c3c071e28c202a744773f39e6391562e35L169-R175) [[3]](diffhunk://#diff-71f0b6f21f0acfecbebde7bd458231c3c071e28c202a744773f39e6391562e35L217-R223) [[4]](diffhunk://#diff-71f0b6f21f0acfecbebde7bd458231c3c071e28c202a744773f39e6391562e35L235-R241)
* Enhanced `bkgdColorPref` in `accountcolors-utilities.js` to:
  - Fallback to the account's background color if an identity's color is not set.
  - Use Thunderbird 128+'s `FolderTreeProperties.getColor` as a final fallback if no preference is found, ensuring color consistency in newer Thunderbird versions.

Addresses https://github.com/Vigilans/accountcolors/issues/34#issue-3478699303