### PR TITLE
Remove strict_max_version cap to support Thunderbird 151+

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,7 @@
     "gecko": {
       "id": "accountcolors@gazhay",
       "strict_min_version": "102.0",
-      "strict_max_version": "150.*"
+      "strict_max_version": "*"
     }
   },
 


### PR DESCRIPTION
Fixes #40

Change `strict_max_version` from `"150.*"` to `"*"` so the add-on is compatible with Thunderbird 151 and future versions.