### PR TITLE
Add reversed gradient direction option

### DIFF
--- a/chrome/content/accountcolors-about3pane.js
+++ b/chrome/content/accountcolors-about3pane.js
@@ -1129,9 +1129,15 @@ var accountColorsAbout3Pane_115 = {
     if (accountColorsAbout3Pane.prefs.getBoolPref("folder-colorbkgd-gradient")) {
       element = accountColorsAbout3Pane.folderTree;
       element.setAttribute("ac-bkgdasgradient", "");
+      if (accountColorsAbout3Pane.prefs.getBoolPref("folder-colorbkgd-gradient-reverse")) {
+        element.setAttribute("ac-bkgdasgradient-reverse", "");
+      } else {
+        element.removeAttribute("ac-bkgdasgradient-reverse");
+      }
     } else {
       element = accountColorsAbout3Pane.folderTree;
       element.removeAttribute("ac-bkgdasgradient");
+      element.removeAttribute("ac-bkgdasgradient-reverse");
     }
 
     /* Black/White row fonts */
@@ -1743,9 +1749,15 @@ var accountColorsAbout3Pane_115 = {
     if (accountColorsAbout3Pane.prefs.getBoolPref("thread-colorbkgd-gradient")) {
       element = accountColorsUtilities.thunderbirdVersion.major > 102 ? document.getElementById("threadPane") : accountColorsAbout3Pane.threadTree;
       element.setAttribute("ac-bkgdasgradient", "");
+      if (accountColorsAbout3Pane.prefs.getBoolPref("thread-colorbkgd-gradient-reverse")) {
+        element.setAttribute("ac-bkgdasgradient-reverse", "");
+      } else {
+        element.removeAttribute("ac-bkgdasgradient-reverse");
+      }
     } else {
       element = accountColorsUtilities.thunderbirdVersion.major > 102 ? document.getElementById("threadPane") : accountColorsAbout3Pane.threadTree;
       element.removeAttribute("ac-bkgdasgradient");
+      element.removeAttribute("ac-bkgdasgradient-reverse");
     }
 
     /* Color row background as label */

--- a/chrome/content/accountcolors-aboutmessage.js
+++ b/chrome/content/accountcolors-aboutmessage.js
@@ -213,7 +213,8 @@ var accountColorsAboutMessage = {
       } else if (accountColorsAboutMessage.prefs.getBoolPref("message-colorbkgd-gradient")) {
         element = document.getElementById("messageHeader");
         if (element != null) {
-          element.style.backgroundImage = "linear-gradient(to right, " + bkgdcolor + " 0%, transparent 100%)";
+          var gradientDir = accountColorsAboutMessage.prefs.getBoolPref("message-colorbkgd-gradient-reverse") ? "to left" : "to right";
+          element.style.backgroundImage = "linear-gradient(" + gradientDir + ", " + bkgdcolor + " 0%, transparent 100%)";
           element.style.backgroundColor = "";
         }
       } else {

--- a/chrome/content/accountcolors-composewindow.js
+++ b/chrome/content/accountcolors-composewindow.js
@@ -79,6 +79,7 @@ var accountColorsCompose = {
   composeWindow: function (event, clear = false) {
     var i, menulist, accountidkey, menupopup, menuitem;
     var defaultbkgd, bkgdcolor, fontcolor, element, idkey, fontstyle, fontsize, width;
+    var gradientDir = accountColorsCompose.prefs.getBoolPref("compose-colorbkgd-gradient-reverse") ? "to left" : "to right";
 
     menulist = document.getElementById("msgIdentity");
 
@@ -110,7 +111,7 @@ var accountColorsCompose = {
       if (defaultbkgd) {
         element.style.backgroundColor = "";
       } else if (accountColorsCompose.prefs.getBoolPref("compose-colorbkgd-gradient")) {
-        element.style.setProperty("background-image", "linear-gradient(to right, " + bkgdcolor + ", transparent 100%", "important");
+        element.style.setProperty("background-image", "linear-gradient(" + gradientDir + ", " + bkgdcolor + ", transparent 100%", "important");
       } else {
         element.style.setProperty("background-color", bkgdcolor, "important");
       }
@@ -178,7 +179,7 @@ var accountColorsCompose = {
         menulist.style.backgroundColor = "";
         menulist.style.backgroundImage = "";
       } else if (accountColorsCompose.prefs.getBoolPref("compose-colorbkgd-gradient")) {
-        menulist.style.backgroundImage = "linear-gradient(to right, " + bkgdcolor + ", transparent 100%)";
+        menulist.style.backgroundImage = "linear-gradient(" + gradientDir + ", " + bkgdcolor + ", transparent 100%)";
         menulist.style.backgroundColor = "";
       } else if (defaultbkgd) {
         menulist = document.getElementById("msgIdentity");
@@ -205,7 +206,7 @@ var accountColorsCompose = {
             menuitem.style.backgroundColor = "";
             menuitem.style.setProperty("border-radius", "0", "");
           } else if (accountColorsCompose.prefs.getBoolPref("compose-colorbkgd-gradient")) {
-            menuitem.style.backgroundImage = "linear-gradient(to right, " + bkgdcolor + ", transparent 100%)";
+            menuitem.style.backgroundImage = "linear-gradient(" + gradientDir + ", " + bkgdcolor + ", transparent 100%)";
             menuitem.style.backgroundColor = "";
             menuitem.style.removeProperty("border-radius");
           } else {
@@ -254,9 +255,15 @@ var accountColorsCompose = {
         document.documentElement.style.removeProperty("--ac-colortobkgd");
         document.getElementById("msgcomposeWindow").removeAttribute("ac-colortobkgd");
         document.getElementById("msgcomposeWindow").removeAttribute("ac-colortobkgd-asgradient");
+        document.getElementById("msgcomposeWindow").removeAttribute("ac-colortobkgd-asgradient-reverse");
       } else if (accountColorsCompose.prefs.getBoolPref("compose-colorbkgd-gradient")) {
         document.documentElement.style.setProperty("--ac-colortobkgd", bkgdcolor, "");
         document.getElementById("msgcomposeWindow").setAttribute("ac-colortobkgd-asgradient", "");
+        if (accountColorsCompose.prefs.getBoolPref("compose-colorbkgd-gradient-reverse")) {
+          document.getElementById("msgcomposeWindow").setAttribute("ac-colortobkgd-asgradient-reverse", "");
+        } else {
+          document.getElementById("msgcomposeWindow").removeAttribute("ac-colortobkgd-asgradient-reverse");
+        }
       } else {
         document.documentElement.style.setProperty("--ac-colortobkgd", bkgdcolor, "");
         document.getElementById("msgcomposeWindow").setAttribute("ac-colortobkgd", "");
@@ -265,6 +272,7 @@ var accountColorsCompose = {
       document.documentElement.style.removeProperty("--ac-colortobkgd");
       document.getElementById("msgcomposeWindow").removeAttribute("ac-colortobkgd");
       document.getElementById("msgcomposeWindow").removeAttribute("ac-colortobkgd-asgradient");
+      document.getElementById("msgcomposeWindow").removeAttribute("ac-colortobkgd-asgradient-reverse");
     }
 
     /* Color attachment font */
@@ -288,7 +296,7 @@ var accountColorsCompose = {
       if (defaultbkgd) {
         element.style.backgroundColor = "";
       } else if (accountColorsCompose.prefs.getBoolPref("compose-colorbkgd-gradient")) {
-        element.style.setProperty("background-image", "linear-gradient(to right, " + bkgdcolor + ", transparent 100%", "important");
+        element.style.setProperty("background-image", "linear-gradient(" + gradientDir + ", " + bkgdcolor + ", transparent 100%", "important");
       } else {
         element.style.setProperty("background-color", bkgdcolor, "important");
       }
@@ -338,7 +346,7 @@ var accountColorsCompose = {
         if (defaultbkgd) {
           element.style.backgroundColor = "";
         } else if (accountColorsCompose.prefs.getBoolPref("compose-colorbkgd-gradient")) {
-          element.style.setProperty("background-image", "linear-gradient(to right, " + bkgdcolor + ", transparent 100%", "important");
+          element.style.setProperty("background-image", "linear-gradient(" + gradientDir + ", " + bkgdcolor + ", transparent 100%", "important");
         } else {
           element.style.setProperty("background-color", bkgdcolor, "important");
         }
@@ -349,7 +357,7 @@ var accountColorsCompose = {
         if (defaultbkgd) {
           element.style.backgroundColor = "";
         } else if (accountColorsCompose.prefs.getBoolPref("compose-colorbkgd-gradient")) {
-          element.style.setProperty("background-image", "linear-gradient(to right, " + bkgdcolor + ", transparent 100%", "important");
+          element.style.setProperty("background-image", "linear-gradient(" + gradientDir + ", " + bkgdcolor + ", transparent 100%", "important");
         } else {
           element.style.setProperty("background-color", bkgdcolor, "important");
         }

--- a/chrome/content/accountcolors-options.js
+++ b/chrome/content/accountcolors-options.js
@@ -488,6 +488,21 @@ var accountColorsOptions = {
       checkbox.checked = false;
     }
 
+    menulist = document.getElementById("accountcolors-folder-colorbkgd-gradient-direction");
+    menulist.disabled = !checkbox.checked;
+    menulist.appendItem("Left to Right", 0);
+    menulist.appendItem("Right to Left", 1);
+    try {
+      if (accountColorsUtilities.thunderbirdVersion.major > 102) {
+        value = accountColorsOptions.prefs.getBoolPref("folder-colorbkgd-gradient-reverse") ? 1 : 0;
+        menulist.selectedIndex = value;
+      } else {
+        menulist.style.display = "none";
+      }
+    } catch (e) {
+      menulist.selectedIndex = 0;
+    }
+
     checkbox = document.getElementById("accountcolors-folder-colorbkgd-account-icon");
     try {
       if (accountColorsUtilities.thunderbirdVersion.major > 102) {
@@ -768,6 +783,21 @@ var accountColorsOptions = {
       checkbox.checked = false;
     }
 
+    menulist = document.getElementById("accountcolors-thread-colorbkgd-gradient-direction");
+    menulist.disabled = !checkbox.checked;
+    menulist.appendItem("Left to Right", 0);
+    menulist.appendItem("Right to Left", 1);
+    try {
+      if (accountColorsUtilities.thunderbirdVersion.major > 102) {
+        value = accountColorsOptions.prefs.getBoolPref("thread-colorbkgd-gradient-reverse") ? 1 : 0;
+        menulist.selectedIndex = value;
+      } else {
+        menulist.style.display = "none";
+      }
+    } catch (e) {
+      menulist.selectedIndex = 0;
+    }
+
     checkbox = document.getElementById("accountcolors-thread-colorbkgd-row-label");
     try {
       if (accountColorsUtilities.thunderbirdVersion.major > 102) {
@@ -1045,6 +1075,21 @@ var accountColorsOptions = {
       }
     } catch (e) {
       checkbox.checked = false;
+    }
+
+    menulist = document.getElementById("accountcolors-message-colorbkgd-gradient-direction");
+    menulist.disabled = !checkbox.checked;
+    menulist.appendItem("Left to Right", 0);
+    menulist.appendItem("Right to Left", 1);
+    try {
+      if (accountColorsUtilities.thunderbirdVersion.major > 102) {
+        value = accountColorsOptions.prefs.getBoolPref("message-colorbkgd-gradient-reverse") ? 1 : 0;
+        menulist.selectedIndex = value;
+      } else {
+        menulist.style.display = "none";
+      }
+    } catch (e) {
+      menulist.selectedIndex = 0;
     }
 
     checkbox = document.getElementById("accountcolors-message-colorbkgd-header-label");
@@ -1356,6 +1401,21 @@ var accountColorsOptions = {
       checkbox.checked = false;
     }
 
+    menulist = document.getElementById("accountcolors-compose-colorbkgd-gradient-direction");
+    menulist.disabled = !checkbox.checked;
+    menulist.appendItem("Left to Right", 0);
+    menulist.appendItem("Right to Left", 1);
+    try {
+      if (accountColorsUtilities.thunderbirdVersion.major > 102) {
+        value = accountColorsOptions.prefs.getBoolPref("compose-colorbkgd-gradient-reverse") ? 1 : 0;
+        menulist.selectedIndex = value;
+      } else {
+        menulist.style.display = "none";
+      }
+    } catch (e) {
+      menulist.selectedIndex = 0;
+    }
+
     checkbox = document.getElementById("accountcolors-compose-colorbkgd-idmenu-label");
     try {
       if (accountColorsUtilities.thunderbirdVersion.major > 102) {
@@ -1438,6 +1498,7 @@ var accountColorsOptions = {
     accountColorsOptions.prefs.setBoolPref("folder-incspacing", document.getElementById("accountcolors-folder-incspacing").checked);
     accountColorsOptions.prefs.setBoolPref("folder-hoverselect", document.getElementById("accountcolors-folder-hoverselect").checked);
     accountColorsOptions.prefs.setBoolPref("folder-colorbkgd-gradient", document.getElementById("accountcolors-folder-colorbkgd-gradient").checked);
+    accountColorsOptions.prefs.setBoolPref("folder-colorbkgd-gradient-reverse", document.getElementById("accountcolors-folder-colorbkgd-gradient-direction").value == 1);
     accountColorsOptions.prefs.setBoolPref("folder-colorbkgd-account-icon", document.getElementById("accountcolors-folder-colorbkgd-account-icon").checked);
     accountColorsOptions.prefs.setBoolPref("folder-colorbkgd-folder-icon", document.getElementById("accountcolors-folder-colorbkgd-folder-icon").checked);
 
@@ -1468,6 +1529,7 @@ var accountColorsOptions = {
     accountColorsOptions.prefs.setBoolPref("thread-incspacing", document.getElementById("accountcolors-thread-incspacing").checked);
     accountColorsOptions.prefs.setBoolPref("thread-hoverselect", document.getElementById("accountcolors-thread-hoverselect").checked);
     accountColorsOptions.prefs.setBoolPref("thread-colorbkgd-gradient", document.getElementById("accountcolors-thread-colorbkgd-gradient").checked);
+    accountColorsOptions.prefs.setBoolPref("thread-colorbkgd-gradient-reverse", document.getElementById("accountcolors-thread-colorbkgd-gradient-direction").value == 1);
     accountColorsOptions.prefs.setBoolPref("thread-colorbkgd-row-label", document.getElementById("accountcolors-thread-colorbkgd-row-label").checked);
     accountColorsOptions.prefs.setIntPref("thread-row-label-position", document.getElementById("accountcolors-thread-row-label-position").value);
     accountColorsOptions.prefs.setIntPref("thread-row-label-width", document.getElementById("accountcolors-thread-row-label-width").value);
@@ -1494,6 +1556,7 @@ var accountColorsOptions = {
     // accountColorsOptions.prefs.setBoolPref("message-defaultbkgd", document.getElementById("accountcolors-message-defaultbkgd").checked);
     accountColorsOptions.prefs.setBoolPref("message-hdraccount", document.getElementById("accountcolors-message-hdraccount").checked);
     accountColorsOptions.prefs.setBoolPref("message-colorbkgd-gradient", document.getElementById("accountcolors-message-colorbkgd-gradient").checked);
+    accountColorsOptions.prefs.setBoolPref("message-colorbkgd-gradient-reverse", document.getElementById("accountcolors-message-colorbkgd-gradient-direction").value == 1);
     accountColorsOptions.prefs.setBoolPref("message-colorbkgd-header-label", document.getElementById("accountcolors-message-colorbkgd-header-label").checked);
     accountColorsOptions.prefs.setIntPref("message-header-label-width", document.getElementById("accountcolors-message-header-label-width").value);
 
@@ -1526,6 +1589,7 @@ var accountColorsOptions = {
     // accountColorsOptions.prefs.setBoolPref("compose-defaultbkgd", document.getElementById("accountcolors-compose-defaultbkgd").checked);
     accountColorsOptions.prefs.setBoolPref("compose-hoverfrom", document.getElementById("accountcolors-compose-hoverfrom").checked);
     accountColorsOptions.prefs.setBoolPref("compose-colorbkgd-gradient", document.getElementById("accountcolors-compose-colorbkgd-gradient").checked);
+    accountColorsOptions.prefs.setBoolPref("compose-colorbkgd-gradient-reverse", document.getElementById("accountcolors-compose-colorbkgd-gradient-direction").value == 1);
     accountColorsOptions.prefs.setBoolPref("compose-colorbkgd-idmenu-label", document.getElementById("accountcolors-compose-colorbkgd-idmenu-label").checked);
     accountColorsOptions.prefs.setIntPref("compose-idmenu-label-width", document.getElementById("accountcolors-compose-idmenu-label-width").value);
   },

--- a/chrome/content/accountcolors-options.xhtml
+++ b/chrome/content/accountcolors-options.xhtml
@@ -123,7 +123,8 @@
         </hbox>
 
         <hbox>
-          <checkbox id="accountcolors-folder-colorbkgd-gradient" label="&accountcolors.folder.colorbkgd.gradient;" />
+          <checkbox id="accountcolors-folder-colorbkgd-gradient" label="&accountcolors.folder.colorbkgd.gradient;" oncommand="accountColorsOptions.setMenuStateByCheckbox(this.id, 'accountcolors-folder-colorbkgd-gradient-direction');" />
+          <menulist id="accountcolors-folder-colorbkgd-gradient-direction" />
         </hbox>
 
         <hbox>
@@ -201,7 +202,8 @@
         </hbox>
 
         <hbox>
-          <checkbox id="accountcolors-thread-colorbkgd-gradient" label="&accountcolors.thread.colorbkgd.gradient;" />
+          <checkbox id="accountcolors-thread-colorbkgd-gradient" label="&accountcolors.thread.colorbkgd.gradient;" oncommand="accountColorsOptions.setMenuStateByCheckbox(this.id, 'accountcolors-thread-colorbkgd-gradient-direction');" />
+          <menulist id="accountcolors-thread-colorbkgd-gradient-direction" />
         </hbox>
 
         <hbox>
@@ -268,7 +270,8 @@
         <separator class="groove section" />
 
         <hbox>
-          <checkbox id="accountcolors-message-colorbkgd-gradient" label="&accountcolors.message.colorbkgd.gradient;" />
+          <checkbox id="accountcolors-message-colorbkgd-gradient" label="&accountcolors.message.colorbkgd.gradient;" oncommand="accountColorsOptions.setMenuStateByCheckbox(this.id, 'accountcolors-message-colorbkgd-gradient-direction');" />
+          <menulist id="accountcolors-message-colorbkgd-gradient-direction" />
         </hbox>
 
         <hbox>
@@ -347,7 +350,8 @@
         </hbox>
 
         <hbox>
-          <checkbox id="accountcolors-compose-colorbkgd-gradient" label="&accountcolors.compose.colorbkgd.gradient;" />
+          <checkbox id="accountcolors-compose-colorbkgd-gradient" label="&accountcolors.compose.colorbkgd.gradient;" oncommand="accountColorsOptions.setMenuStateByCheckbox(this.id, 'accountcolors-compose-colorbkgd-gradient-direction');" />
+          <menulist id="accountcolors-compose-colorbkgd-gradient-direction" />
         </hbox>
 
         <hbox>

--- a/chrome/locale/de/accountcolors.dtd
+++ b/chrome/locale/de/accountcolors.dtd
@@ -34,7 +34,7 @@
 <!ENTITY accountcolors.folder.darkerbar "Dunklere Auswahlleiste">
 <!ENTITY accountcolors.folder.incspacing "Zeilenabstand an die Schriftgröße der Konten-Bezeichnung anpassen">
 <!ENTITY accountcolors.folder.hoverselect "Reinstate default hover and select styles">
-<!ENTITY accountcolors.folder.colorbkgd.gradient "Color Background as Gradient">
+<!ENTITY accountcolors.folder.colorbkgd.gradient "Color Background as Gradient from">
 <!ENTITY accountcolors.folder.colorbkgd.account.icon "Render Account Background Color as Icon Color">
 <!ENTITY accountcolors.folder.colorbkgd.folder.icon "Render Folder Background Color as Icon Color">
 
@@ -59,7 +59,7 @@
 <!ENTITY accountcolors.thread.darkerbar "Dunklere Farben für nicht-fokussierte Auswahlleiste">
 <!ENTITY accountcolors.thread.incspacing "Zeilenabstand an die Schriftgröße der Betreffzeile anpassen">
 <!ENTITY accountcolors.thread.hoverselect "Reinstate default hover and select styles">
-<!ENTITY accountcolors.thread.colorbkgd.gradient "Color Background as Gradient">
+<!ENTITY accountcolors.thread.colorbkgd.gradient "Color Background as Gradient from">
 <!ENTITY accountcolors.thread.colorbkgd.row.label    "Color Row Background as Label in Table View on">
 <!ENTITY accountcolors.thread.colorbkgd.card.label   "Color Row Background as Label in Card View with">
 <!ENTITY accountcolors.thread.color.unified.only "Only Color in Unified Folder">
@@ -75,7 +75,7 @@
 <!ENTITY accountcolors.message.whitehdrlabels   "White Header Labels">
 <!ENTITY accountcolors.message.hdraccount "Farben je nach Empfängerkonto anders">
 <!ENTITY accountcolors.message.defaultbkgd "Retain default light/dark background if White selected">
-<!ENTITY accountcolors.message.colorbkgd.gradient "Color Background as Gradient">
+<!ENTITY accountcolors.message.colorbkgd.gradient "Color Background as Gradient from">
 <!ENTITY accountcolors.message.colorbkgd.header.label "Color Header Background as Label">
 
 <!ENTITY accountcolors.compose.setfontstyle "Betreffzeilen-Schriftstil:">
@@ -100,7 +100,7 @@
 <!ENTITY accountcolors.compose.darkfieldbkgd "Dark Field Backgrounds (on hover or focus)">
 <!ENTITY accountcolors.compose.defaultbkgd "Retain default light/dark background if White selected">
 <!ENTITY accountcolors.compose.hoverfrom "Reinstate default hover style (on From menu)">
-<!ENTITY accountcolors.compose.colorbkgd.gradient "Color Background as Gradient">
+<!ENTITY accountcolors.compose.colorbkgd.gradient "Color Background as Gradient from">
 <!ENTITY accountcolors.compose.colorbkgd.idmenu.label "Color Identity Background in From Menu as Label">
 
 <!ENTITY accountcolors.picker.fonttitle "Farbauswahl-Text">

--- a/chrome/locale/en-US/accountcolors.dtd
+++ b/chrome/locale/en-US/accountcolors.dtd
@@ -39,7 +39,7 @@
 <!ENTITY accountcolors.folder.darkerbar         "Darker Unfocused Select Bar">
 <!ENTITY accountcolors.folder.incspacing        "Increase Row Spacing based on Account Font Size (even if Account Font Size not ticked)">
 <!ENTITY accountcolors.folder.hoverselect       "Reinstate default hover and select styles">
-<!ENTITY accountcolors.folder.colorbkgd.gradient "Color Background as Gradient">
+<!ENTITY accountcolors.folder.colorbkgd.gradient "Color Background as Gradient from">
 <!ENTITY accountcolors.folder.colorbkgd.account.icon "Render Account Background Color as Icon Color">
 <!ENTITY accountcolors.folder.colorbkgd.folder.icon "Render Folder Background Color as Icon Color">
 
@@ -64,7 +64,7 @@
 <!ENTITY accountcolors.thread.darkerbar         "Darker Unfocused Select Bar">
 <!ENTITY accountcolors.thread.incspacing        "Increase Row Spacing based on Subject/From Font Sizes (even if Subject/From Font Sizes not ticked)">
 <!ENTITY accountcolors.thread.hoverselect       "Reinstate default hover and select styles">
-<!ENTITY accountcolors.thread.colorbkgd.gradient "Color Background as Gradient">
+<!ENTITY accountcolors.thread.colorbkgd.gradient "Color Background as Gradient from">
 <!ENTITY accountcolors.thread.colorbkgd.row.label    "Color Row Background as Label in Table View on">
 <!ENTITY accountcolors.thread.colorbkgd.card.label   "Color Row Background as Label in Card View with">
 <!ENTITY accountcolors.thread.color.unified.only "Only Color in Unified Folder">
@@ -80,7 +80,7 @@
 <!ENTITY accountcolors.message.whitehdrlabels   "White Header Labels">
 <!ENTITY accountcolors.message.hdraccount       "Color based on Account of Received Email&apos;s Address (instead of Folder&apos;s Account)">
 <!ENTITY accountcolors.message.defaultbkgd "Retain default light/dark background if White selected">
-<!ENTITY accountcolors.message.colorbkgd.gradient "Color Background as Gradient">
+<!ENTITY accountcolors.message.colorbkgd.gradient "Color Background as Gradient from">
 <!ENTITY accountcolors.message.colorbkgd.header.label "Color Header Background as Label">
 
 <!ENTITY accountcolors.compose.setfontstyle     "Subject Font Style">
@@ -105,7 +105,7 @@
 <!ENTITY accountcolors.compose.darkfieldbkgd    "Dark Field Backgrounds (on hover or focus)">
 <!ENTITY accountcolors.compose.defaultbkgd "Retain default light/dark background if White selected">
 <!ENTITY accountcolors.compose.hoverfrom        "Reinstate default hover style (on From menu)">
-<!ENTITY accountcolors.compose.colorbkgd.gradient "Color Background as Gradient">
+<!ENTITY accountcolors.compose.colorbkgd.gradient "Color Background as Gradient from">
 <!ENTITY accountcolors.compose.colorbkgd.idmenu.label "Color Identity Background in From Menu as Label">
 
 <!ENTITY accountcolors.picker.fonttitle         "Font Color Picker">

--- a/chrome/locale/es-ES/accountcolors.dtd
+++ b/chrome/locale/es-ES/accountcolors.dtd
@@ -34,7 +34,7 @@
 <!ENTITY accountcolors.folder.darkerbar "Barra de Selección mas Oscura">
 <!ENTITY accountcolors.folder.incspacing "Incrementar espaciado de líneas en el tamaño de fuente de la cuenta (incluso si el tamaño de la cuenta no se ha marcado)">
 <!ENTITY accountcolors.folder.hoverselect "Reinstate default hover and select styles">
-<!ENTITY accountcolors.folder.colorbkgd.gradient "Color Background as Gradient">
+<!ENTITY accountcolors.folder.colorbkgd.gradient "Color Background as Gradient from">
 <!ENTITY accountcolors.folder.colorbkgd.account.icon "Render Account Background Color as Icon Color">
 <!ENTITY accountcolors.folder.colorbkgd.folder.icon "Render Folder Background Color as Icon Color">
 
@@ -59,7 +59,7 @@
 <!ENTITY accountcolors.thread.darkerbar "Barra Seleccionada mas Oscura">
 <!ENTITY accountcolors.thread.incspacing "Incrementar espaciado de líneas en el tamaño de la fuente del remitente (incluso si el tamaño de la fuente del remitente no se ha marcado)">
 <!ENTITY accountcolors.thread.hoverselect "Reinstate default hover and select styles">
-<!ENTITY accountcolors.thread.colorbkgd.gradient "Color Background as Gradient">
+<!ENTITY accountcolors.thread.colorbkgd.gradient "Color Background as Gradient from">
 <!ENTITY accountcolors.thread.colorbkgd.row.label    "Color Row Background as Label in Table View on">
 <!ENTITY accountcolors.thread.colorbkgd.card.label   "Color Row Background as Label in Card View with">
 <!ENTITY accountcolors.thread.color.unified.only "Only Color in Unified Folder">
@@ -75,7 +75,7 @@
 <!ENTITY accountcolors.message.whitehdrlabels "White Header Labels">
 <!ENTITY accountcolors.message.hdraccount "Color basado en la cabecera de cuenta de mensaje (en lugar de carpeta de la cuenta)">
 <!ENTITY accountcolors.message.defaultbkgd "Retain default light/dark background if White selected">
-<!ENTITY accountcolors.message.colorbkgd.gradient "Color Background as Gradient">
+<!ENTITY accountcolors.message.colorbkgd.gradient "Color Background as Gradient from">
 <!ENTITY accountcolors.message.colorbkgd.header.label "Color Header Background as Label">
 
 <!ENTITY accountcolors.compose.setfontstyle "Estilo de fuente del Asunto">
@@ -100,7 +100,7 @@
 <!ENTITY accountcolors.compose.darkfieldbkgd "Dark Field Backgrounds (on hover or focus)">
 <!ENTITY accountcolors.compose.defaultbkgd "Retain default light/dark background if White selected">
 <!ENTITY accountcolors.compose.hoverfrom "Reinstate default hover style (on From menu)">
-<!ENTITY accountcolors.compose.colorbkgd.gradient "Color Background as Gradient">
+<!ENTITY accountcolors.compose.colorbkgd.gradient "Color Background as Gradient from">
 <!ENTITY accountcolors.compose.colorbkgd.idmenu.label "Color Identity Background in From Menu as Label">
 
 <!ENTITY accountcolors.picker.fonttitle "Selector de color de fuente">

--- a/chrome/locale/fi-FI/accountcolors.dtd
+++ b/chrome/locale/fi-FI/accountcolors.dtd
@@ -34,7 +34,7 @@
 <!ENTITY accountcolors.folder.darkerbar "Tummempi valintapalkki">
 <!ENTITY accountcolors.folder.incspacing "Lisää riviväliä riippuen tilin fontin koosta (vaikka tilin fonttikokoa ei ole valittu)">
 <!ENTITY accountcolors.folder.hoverselect "Reinstate default hover and select styles">
-<!ENTITY accountcolors.folder.colorbkgd.gradient "Color Background as Gradient">
+<!ENTITY accountcolors.folder.colorbkgd.gradient "Color Background as Gradient from">
 <!ENTITY accountcolors.folder.colorbkgd.account.icon "Render Account Background Color as Icon Color">
 <!ENTITY accountcolors.folder.colorbkgd.folder.icon "Render Folder Background Color as Icon Color">
 
@@ -59,7 +59,7 @@
 <!ENTITY accountcolors.thread.darkerbar "Tummempi valintapalkki">
 <!ENTITY accountcolors.thread.incspacing "Lisää riviväliä riippuen aiheen fonttikoosta (vaikka aiheen fonttikokoa ei ole valittu)">
 <!ENTITY accountcolors.thread.hoverselect "Reinstate default hover and select styles">
-<!ENTITY accountcolors.thread.colorbkgd.gradient "Color Background as Gradient">
+<!ENTITY accountcolors.thread.colorbkgd.gradient "Color Background as Gradient from">
 <!ENTITY accountcolors.thread.colorbkgd.row.label    "Color Row Background as Label in Table View on">
 <!ENTITY accountcolors.thread.colorbkgd.card.label   "Color Row Background as Label in Card View with">
 <!ENTITY accountcolors.thread.color.unified.only "Only Color in Unified Folder">
@@ -75,7 +75,7 @@
 <!ENTITY accountcolors.message.whitehdrlabels "White Header Labels">
 <!ENTITY accountcolors.message.hdraccount "Väritys riippuu viestiin liittyvän tilin värityksestä (kansion värityksen sijasta)">
 <!ENTITY accountcolors.message.defaultbkgd "Retain default light/dark background if White selected">
-<!ENTITY accountcolors.message.colorbkgd.gradient "Color Background as Gradient">
+<!ENTITY accountcolors.message.colorbkgd.gradient "Color Background as Gradient from">
 <!ENTITY accountcolors.message.colorbkgd.header.label "Color Header Background as Label">
 
 <!ENTITY accountcolors.compose.setfontstyle "Aiheen fonttityyli">
@@ -100,7 +100,7 @@
 <!ENTITY accountcolors.compose.darkfieldbkgd "Dark Field Backgrounds (on hover or focus)">
 <!ENTITY accountcolors.compose.defaultbkgd "Retain default light/dark background if White selected">
 <!ENTITY accountcolors.compose.hoverfrom "Reinstate default hover style (on From menu)">
-<!ENTITY accountcolors.compose.colorbkgd.gradient "Color Background as Gradient">
+<!ENTITY accountcolors.compose.colorbkgd.gradient "Color Background as Gradient from">
 <!ENTITY accountcolors.compose.colorbkgd.idmenu.label "Color Identity Background in From Menu as Label">
 
 <!ENTITY accountcolors.picker.fonttitle "Fonttivärin valitsin">

--- a/chrome/locale/fi/accountcolors.dtd
+++ b/chrome/locale/fi/accountcolors.dtd
@@ -34,7 +34,7 @@
 <!ENTITY accountcolors.folder.darkerbar "Tummempi valintapalkki">
 <!ENTITY accountcolors.folder.incspacing "Lisää riviväliä riippuen tilin fontin koosta (vaikka tilin fonttikokoa ei ole valittu)">
 <!ENTITY accountcolors.folder.hoverselect "Reinstate default hover and select styles">
-<!ENTITY accountcolors.folder.colorbkgd.gradient "Color Background as Gradient">
+<!ENTITY accountcolors.folder.colorbkgd.gradient "Color Background as Gradient from">
 <!ENTITY accountcolors.folder.colorbkgd.account.icon "Render Account Background Color as Icon Color">
 <!ENTITY accountcolors.folder.colorbkgd.folder.icon "Render Folder Background Color as Icon Color">
 
@@ -59,7 +59,7 @@
 <!ENTITY accountcolors.thread.darkerbar "Tummempi valintapalkki">
 <!ENTITY accountcolors.thread.incspacing "Lisää riviväliä riippuen aiheen fonttikoosta (vaikka aiheen fonttikokoa ei ole valittu)">
 <!ENTITY accountcolors.thread.hoverselect "Reinstate default hover and select styles">
-<!ENTITY accountcolors.thread.colorbkgd.gradient "Color Background as Gradient">
+<!ENTITY accountcolors.thread.colorbkgd.gradient "Color Background as Gradient from">
 <!ENTITY accountcolors.thread.colorbkgd.row.label    "Color Row Background as Label in Table View on">
 <!ENTITY accountcolors.thread.colorbkgd.card.label   "Color Row Background as Label in Card View with">
 <!ENTITY accountcolors.thread.color.unified.only "Only Color in Unified Folder">
@@ -75,7 +75,7 @@
 <!ENTITY accountcolors.message.whitehdrlabels "White Header Labels">
 <!ENTITY accountcolors.message.hdraccount "Väritys riippuu viestiin liittyvän tilin värityksestä (kansion värityksen sijasta)">
 <!ENTITY accountcolors.message.defaultbkgd "Retain default light/dark background if White selected">
-<!ENTITY accountcolors.message.colorbkgd.gradient "Color Background as Gradient">
+<!ENTITY accountcolors.message.colorbkgd.gradient "Color Background as Gradient from">
 <!ENTITY accountcolors.message.colorbkgd.header.label "Color Header Background as Label">
 
 <!ENTITY accountcolors.compose.setfontstyle "Aiheen fonttityyli">
@@ -100,7 +100,7 @@
 <!ENTITY accountcolors.compose.darkfieldbkgd "Dark Field Backgrounds (on hover or focus)">
 <!ENTITY accountcolors.compose.defaultbkgd "Retain default light/dark background if White selected">
 <!ENTITY accountcolors.compose.hoverfrom "Reinstate default hover style (on From menu)">
-<!ENTITY accountcolors.compose.colorbkgd.gradient "Color Background as Gradient">
+<!ENTITY accountcolors.compose.colorbkgd.gradient "Color Background as Gradient from">
 <!ENTITY accountcolors.compose.colorbkgd.idmenu.label "Color Identity Background in From Menu as Label">
 
 <!ENTITY accountcolors.picker.fonttitle "Fonttivärin valitsin">

--- a/chrome/locale/fr/accountcolors.dtd
+++ b/chrome/locale/fr/accountcolors.dtd
@@ -34,7 +34,7 @@
 <!ENTITY accountcolors.folder.darkerbar "Barre de sélection plus sombre">
 <!ENTITY accountcolors.folder.incspacing "Augmenter l'espacement entre les lignes en fonction de la taille de la police des comptes (même si cette taille n'est pas sélectionnée)">
 <!ENTITY accountcolors.folder.hoverselect "Reinstate default hover and select styles">
-<!ENTITY accountcolors.folder.colorbkgd.gradient "Color Background as Gradient">
+<!ENTITY accountcolors.folder.colorbkgd.gradient "Color Background as Gradient from">
 <!ENTITY accountcolors.folder.colorbkgd.account.icon "Render Account Background Color as Icon Color">
 <!ENTITY accountcolors.folder.colorbkgd.folder.icon "Render Folder Background Color as Icon Color">
 
@@ -59,7 +59,7 @@
 <!ENTITY accountcolors.thread.darkerbar "Barre de sélection plus sombre">
 <!ENTITY accountcolors.thread.incspacing "Augmenter l'espacement entre les lignes en fonction de la taille de la police du sujet (même si cette taille n'est pas sélectionnée)">
 <!ENTITY accountcolors.thread.hoverselect "Reinstate default hover and select styles">
-<!ENTITY accountcolors.thread.colorbkgd.gradient "Color Background as Gradient">
+<!ENTITY accountcolors.thread.colorbkgd.gradient "Color Background as Gradient from">
 <!ENTITY accountcolors.thread.colorbkgd.row.label    "Color Row Background as Label in Table View on">
 <!ENTITY accountcolors.thread.colorbkgd.card.label   "Color Row Background as Label in Card View with">
 <!ENTITY accountcolors.thread.color.unified.only "Only Color in Unified Folder">
@@ -75,7 +75,7 @@
 <!ENTITY accountcolors.message.whitehdrlabels "White Header Labels">
 <!ENTITY accountcolors.message.hdraccount "Couleur basée sur l'en-tête du message et non le dossier du compte">
 <!ENTITY accountcolors.message.defaultbkgd "Retain default light/dark background if White selected">
-<!ENTITY accountcolors.message.colorbkgd.gradient "Color Background as Gradient">
+<!ENTITY accountcolors.message.colorbkgd.gradient "Color Background as Gradient from">
 <!ENTITY accountcolors.message.colorbkgd.header.label "Color Header Background as Label">
 
 <!ENTITY accountcolors.compose.setfontstyle "Style de la police du sujet">
@@ -100,7 +100,7 @@
 <!ENTITY accountcolors.compose.darkfieldbkgd "Dark Field Backgrounds (on hover or focus)">
 <!ENTITY accountcolors.compose.defaultbkgd "Retain default light/dark background if White selected">
 <!ENTITY accountcolors.compose.hoverfrom "Reinstate default hover style (on From menu)">
-<!ENTITY accountcolors.compose.colorbkgd.gradient "Color Background as Gradient">
+<!ENTITY accountcolors.compose.colorbkgd.gradient "Color Background as Gradient from">
 <!ENTITY accountcolors.compose.colorbkgd.idmenu.label "Color Identity Background in From Menu as Label">
 
 <!ENTITY accountcolors.picker.fonttitle "Palette de couleurs de la police">

--- a/chrome/locale/it/accountcolors.dtd
+++ b/chrome/locale/it/accountcolors.dtd
@@ -34,7 +34,7 @@
 <!ENTITY accountcolors.folder.darkerbar "Barra di selezione più scura">
 <!ENTITY accountcolors.folder.incspacing "Aumenta spaziatura righe in base alla dimensione font Account (anche se dimensione font Account non è selezionata)">
 <!ENTITY accountcolors.folder.hoverselect "Reinstate default hover and select styles">
-<!ENTITY accountcolors.folder.colorbkgd.gradient "Color Background as Gradient">
+<!ENTITY accountcolors.folder.colorbkgd.gradient "Color Background as Gradient from">
 <!ENTITY accountcolors.folder.colorbkgd.account.icon "Render Account Background Color as Icon Color">
 <!ENTITY accountcolors.folder.colorbkgd.folder.icon "Render Folder Background Color as Icon Color">
 
@@ -59,7 +59,7 @@
 <!ENTITY accountcolors.thread.darkerbar "Barra di selezione più scura">
 <!ENTITY accountcolors.thread.incspacing "Aumenta spaziatura righe in base alla dimensione font Oggetto (anche se dimensione font Oggetto non è selezionata)">
 <!ENTITY accountcolors.thread.hoverselect "Reinstate default hover and select styles">
-<!ENTITY accountcolors.thread.colorbkgd.gradient "Color Background as Gradient">
+<!ENTITY accountcolors.thread.colorbkgd.gradient "Color Background as Gradient from">
 <!ENTITY accountcolors.thread.colorbkgd.row.label    "Color Row Background as Label in Table View on">
 <!ENTITY accountcolors.thread.colorbkgd.card.label   "Color Row Background as Label in Card View with">
 <!ENTITY accountcolors.thread.color.unified.only "Only Color in Unified Folder">
@@ -75,7 +75,7 @@
 <!ENTITY accountcolors.message.whitehdrlabels "White Header Labels">
 <!ENTITY accountcolors.message.hdraccount "Colore in base all'Account nell'header del messaggio (invece dell'Account della cartella)">
 <!ENTITY accountcolors.message.defaultbkgd "Retain default light/dark background if White selected">
-<!ENTITY accountcolors.message.colorbkgd.gradient "Color Background as Gradient">
+<!ENTITY accountcolors.message.colorbkgd.gradient "Color Background as Gradient from">
 <!ENTITY accountcolors.message.colorbkgd.header.label "Color Header Background as Label">
 
 <!ENTITY accountcolors.compose.setfontstyle "Style font Oggetto">
@@ -100,7 +100,7 @@
 <!ENTITY accountcolors.compose.darkfieldbkgd "Dark Field Backgrounds (on hover or focus)">
 <!ENTITY accountcolors.compose.defaultbkgd "Retain default light/dark background if White selected">
 <!ENTITY accountcolors.compose.hoverfrom "Reinstate default hover style (on From menu)">
-<!ENTITY accountcolors.compose.colorbkgd.gradient "Color Background as Gradient">
+<!ENTITY accountcolors.compose.colorbkgd.gradient "Color Background as Gradient from">
 <!ENTITY accountcolors.compose.colorbkgd.idmenu.label "Color Identity Background in From Menu as Label">
 
 <!ENTITY accountcolors.picker.fonttitle "Selettore colore font">

--- a/chrome/locale/pt-BR/accountcolors.dtd
+++ b/chrome/locale/pt-BR/accountcolors.dtd
@@ -34,7 +34,7 @@
 <!ENTITY accountcolors.folder.darkerbar "Escurecer Barra da Seleção">
 <!ENTITY accountcolors.folder.incspacing "Aumentar espaço entre linhas baseado no tamanho da fonte das contas (mesmo se este não estiver personalizado)">
 <!ENTITY accountcolors.folder.hoverselect "Reinstate default hover and select styles">
-<!ENTITY accountcolors.folder.colorbkgd.gradient "Color Background as Gradient">
+<!ENTITY accountcolors.folder.colorbkgd.gradient "Color Background as Gradient from">
 <!ENTITY accountcolors.folder.colorbkgd.account.icon "Render Account Background Color as Icon Color">
 <!ENTITY accountcolors.folder.colorbkgd.folder.icon "Render Folder Background Color as Icon Color">
 
@@ -59,7 +59,7 @@
 <!ENTITY accountcolors.thread.darkerbar "Escurecer barra da seleção">
 <!ENTITY accountcolors.thread.incspacing "Aumentar espaço entre linhas baseado no tamanho da fonte do assunto (mesmo se esta não for personalizada)">
 <!ENTITY accountcolors.thread.hoverselect "Reinstate default hover and select styles">
-<!ENTITY accountcolors.thread.colorbkgd.gradient "Color Background as Gradient">
+<!ENTITY accountcolors.thread.colorbkgd.gradient "Color Background as Gradient from">
 <!ENTITY accountcolors.thread.colorbkgd.row.label    "Color Row Background as Label in Table View on">
 <!ENTITY accountcolors.thread.colorbkgd.card.label   "Color Row Background as Label in Card View with">
 <!ENTITY accountcolors.thread.color.unified.only "Only Color in Unified Folder">
@@ -75,7 +75,7 @@
 <!ENTITY accountcolors.message.whitehdrlabels "White Header Labels">
 <!ENTITY accountcolors.message.hdraccount "Cor baseada na conta do cabeçalho da mensagem (ao invés da conta da pasta)">
 <!ENTITY accountcolors.message.defaultbkgd "Retain default light/dark background if White selected">
-<!ENTITY accountcolors.message.colorbkgd.gradient "Color Background as Gradient">
+<!ENTITY accountcolors.message.colorbkgd.gradient "Color Background as Gradient from">
 <!ENTITY accountcolors.message.colorbkgd.header.label "Color Header Background as Label">
 
 <!ENTITY accountcolors.compose.setfontstyle "Estilo da fonte do assunto">
@@ -100,7 +100,7 @@
 <!ENTITY accountcolors.compose.darkfieldbkgd "Dark Field Backgrounds (on hover or focus)">
 <!ENTITY accountcolors.compose.defaultbkgd "Retain default light/dark background if White selected">
 <!ENTITY accountcolors.compose.hoverfrom "Reinstate default hover style (on From menu)">
-<!ENTITY accountcolors.compose.colorbkgd.gradient "Color Background as Gradient">
+<!ENTITY accountcolors.compose.colorbkgd.gradient "Color Background as Gradient from">
 <!ENTITY accountcolors.compose.colorbkgd.idmenu.label "Color Identity Background in From Menu as Label">
 
 <!ENTITY accountcolors.picker.fonttitle "Escolher cor da fonte">

--- a/chrome/locale/sv-SE/accountcolors.dtd
+++ b/chrome/locale/sv-SE/accountcolors.dtd
@@ -34,7 +34,7 @@
 <!ENTITY accountcolors.folder.darkerbar "Mörkare färgning av markerat fält">
 <!ENTITY accountcolors.folder.incspacing "Öka radavståndet baserat på teckenstorleken för konton (även om &quot;Teckenstorlek för konto&quot; inte är markerat)">
 <!ENTITY accountcolors.folder.hoverselect "Reinstate default hover and select styles">
-<!ENTITY accountcolors.folder.colorbkgd.gradient "Color Background as Gradient">
+<!ENTITY accountcolors.folder.colorbkgd.gradient "Color Background as Gradient from">
 <!ENTITY accountcolors.folder.colorbkgd.account.icon "Render Account Background Color as Icon Color">
 <!ENTITY accountcolors.folder.colorbkgd.folder.icon "Render Folder Background Color as Icon Color">
 
@@ -59,7 +59,7 @@
 <!ENTITY accountcolors.thread.darkerbar "Mörkare färgning av markerat fält">
 <!ENTITY accountcolors.thread.incspacing "Öka radavståndet baserat på teckenstorleken för ämnesrader (även om &quot;Teckenstorlek för ämnesrad&quot; inte är markerat)">
 <!ENTITY accountcolors.thread.hoverselect "Reinstate default hover and select styles">
-<!ENTITY accountcolors.thread.colorbkgd.gradient "Color Background as Gradient">
+<!ENTITY accountcolors.thread.colorbkgd.gradient "Color Background as Gradient from">
 <!ENTITY accountcolors.thread.colorbkgd.row.label    "Color Row Background as Label in Table View on">
 <!ENTITY accountcolors.thread.colorbkgd.card.label   "Color Row Background as Label in Card View with">
 <!ENTITY accountcolors.thread.color.unified.only "Only Color in Unified Folder">
@@ -75,7 +75,7 @@
 <!ENTITY accountcolors.message.whitehdrlabels "White Header Labels">
 <!ENTITY accountcolors.message.hdraccount "Färga baserat på meddelandehuvudets konto (istället för mappens konto)">
 <!ENTITY accountcolors.message.defaultbkgd "Retain default light/dark background if White selected">
-<!ENTITY accountcolors.message.colorbkgd.gradient "Color Background as Gradient">
+<!ENTITY accountcolors.message.colorbkgd.gradient "Color Background as Gradient from">
 <!ENTITY accountcolors.message.colorbkgd.header.label "Color Header Background as Label">
 
 <!ENTITY accountcolors.compose.setfontstyle "Teckenstil för ämnesrad">
@@ -100,7 +100,7 @@
 <!ENTITY accountcolors.compose.darkfieldbkgd "Dark Field Backgrounds (on hover or focus)">
 <!ENTITY accountcolors.compose.defaultbkgd "Retain default light/dark background if White selected">
 <!ENTITY accountcolors.compose.hoverfrom "Reinstate default hover style (on From menu)">
-<!ENTITY accountcolors.compose.colorbkgd.gradient "Color Background as Gradient">
+<!ENTITY accountcolors.compose.colorbkgd.gradient "Color Background as Gradient from">
 <!ENTITY accountcolors.compose.colorbkgd.idmenu.label "Color Identity Background in From Menu as Label">
 
 <!ENTITY accountcolors.picker.fonttitle "Font Color Picker">

--- a/chrome/locale/zh-CN/accountcolors.dtd
+++ b/chrome/locale/zh-CN/accountcolors.dtd
@@ -34,7 +34,7 @@
 <!ENTITY accountcolors.folder.darkerbar "暗色选择栏">
 <!ENTITY accountcolors.folder.incspacing "基于帐户字体大小增加行间距（即使帐户字体大小未勾选）">
 <!ENTITY accountcolors.folder.hoverselect "Reinstate default hover and select styles">
-<!ENTITY accountcolors.folder.colorbkgd.gradient "Color Background as Gradient">
+<!ENTITY accountcolors.folder.colorbkgd.gradient "Color Background as Gradient from">
 <!ENTITY accountcolors.folder.colorbkgd.account.icon "Render Account Background Color as Icon Color">
 <!ENTITY accountcolors.folder.colorbkgd.folder.icon "Render Folder Background Color as Icon Color">
 
@@ -59,7 +59,7 @@
 <!ENTITY accountcolors.thread.darkerbar "暗色选择栏">
 <!ENTITY accountcolors.thread.incspacing "基于话题字体大小增加行间距（即使话题字体大小未勾选）">
 <!ENTITY accountcolors.thread.hoverselect "Reinstate default hover and select styles">
-<!ENTITY accountcolors.thread.colorbkgd.gradient "Color Background as Gradient">
+<!ENTITY accountcolors.thread.colorbkgd.gradient "Color Background as Gradient from">
 <!ENTITY accountcolors.thread.colorbkgd.row.label    "Color Row Background as Label in Table View on">
 <!ENTITY accountcolors.thread.colorbkgd.card.label   "Color Row Background as Label in Card View with">
 <!ENTITY accountcolors.thread.color.unified.only "Only Color in Unified Folder">
@@ -74,7 +74,7 @@
 <!ENTITY accountcolors.message.whitehdrlabels "White Header Labels">
 <!ENTITY accountcolors.message.hdraccount "基于消息标头帐户的颜色（文件夹帐户的替代）">
 <!ENTITY accountcolors.message.defaultbkgd "Retain default light/dark background if White selected">
-<!ENTITY accountcolors.message.colorbkgd.gradient "Color Background as Gradient">
+<!ENTITY accountcolors.message.colorbkgd.gradient "Color Background as Gradient from">
 <!ENTITY accountcolors.message.colorbkgd.header.label "Color Header Background as Label">
 
 <!ENTITY accountcolors.compose.setfontstyle "话题字体样式">
@@ -99,7 +99,7 @@
 <!ENTITY accountcolors.compose.darkfieldbkgd "Dark Field Backgrounds (on hover or focus)">
 <!ENTITY accountcolors.compose.defaultbkgd "Retain default light/dark background if White selected">
 <!ENTITY accountcolors.compose.hoverfrom "Reinstate default hover style (on From menu)">
-<!ENTITY accountcolors.compose.colorbkgd.gradient "Color Background as Gradient">
+<!ENTITY accountcolors.compose.colorbkgd.gradient "Color Background as Gradient from">
 <!ENTITY accountcolors.compose.colorbkgd.idmenu.label "Color Identity Background in From Menu as Label">
 
 <!ENTITY accountcolors.picker.fonttitle "字体颜色选择器">

--- a/chrome/skin/accountcolors-about3pane-115.css
+++ b/chrome/skin/accountcolors-about3pane-115.css
@@ -80,6 +80,16 @@
     background-color: unset;
 }
 
+#folderTree[ac-bkgdasgradient][ac-bkgdasgradient-reverse] li[is="folder-tree-row"]:not(.selected) > .container {
+    background-image: linear-gradient(to left,
+        var(--ac-bkgd-color),
+        color-mix(in srgb, var(--ac-bkgd-color) 80%, transparent) 4%,
+        color-mix(in srgb, var(--ac-bkgd-color) 60%, transparent) 8%,
+        color-mix(in srgb, var(--ac-bkgd-color) 40%, transparent) 16%,
+        color-mix(in srgb, var(--ac-bkgd-color) 20%, transparent) 32%,
+        transparent 100%);
+}
+
 /* Folder Pane - Font Style / Font Weight */
 
 #folderTree li[is="folder-tree-row"][ac-fsw="normal"] { font-style: normal; font-weight:normal; }
@@ -240,9 +250,17 @@
     background-color: unset;
 }
 
+#threadPane[ac-bkgdasgradient][ac-bkgdasgradient-reverse] tr:not(.selected) {
+    background-image: linear-gradient(to left, var(--ac-bkgd-color), transparent 100%);
+}
+
 #threadPane[ac-colorpanebkgd][ac-bkgdasgradient] > #threadTree {
     background-image: linear-gradient(to right, var(--ac-bkgd-color, var(--tree-view-bg)), transparent 100%);
     background-color: var(--tree-view-bg);
+}
+
+#threadPane[ac-colorpanebkgd][ac-bkgdasgradient][ac-bkgdasgradient-reverse] > #threadTree {
+    background-image: linear-gradient(to left, var(--ac-bkgd-color, var(--tree-view-bg)), transparent 100%);
 }
 
 /* Thread Pane - Font Style / Font Weight */

--- a/chrome/skin/accountcolors-about3pane-128.css
+++ b/chrome/skin/accountcolors-about3pane-128.css
@@ -64,6 +64,16 @@
     background-color: unset;
 }
 
+#folderTree[ac-bkgdasgradient][ac-bkgdasgradient-reverse] li[is="folder-tree-row"]:not(.selected) > .container {
+    background-image: linear-gradient(to left,
+        var(--ac-bkgd-color),
+        color-mix(in srgb, var(--ac-bkgd-color) 80%, transparent) 4%,
+        color-mix(in srgb, var(--ac-bkgd-color) 60%, transparent) 8%,
+        color-mix(in srgb, var(--ac-bkgd-color) 40%, transparent) 16%,
+        color-mix(in srgb, var(--ac-bkgd-color) 20%, transparent) 32%,
+        transparent 100%);
+}
+
 /* Folder Pane - Font Style / Font Weight */
 
 #folderTree li[is="folder-tree-row"][ac-fsw="normal"] { font-style: normal; font-weight:normal; }
@@ -210,9 +220,17 @@
     background-color: unset;
 }
 
+#threadPane[ac-bkgdasgradient][ac-bkgdasgradient-reverse] tr:not(.selected) .card-container {
+    background-image: linear-gradient(to left, var(--ac-bkgd-color), transparent 100%);
+}
+
 #threadPane[ac-colorpanebkgd][ac-bkgdasgradient] > #threadTree {
     background-image: linear-gradient(to right, var(--ac-bkgd-color, var(--tree-view-bg)), transparent 100%);
     background-color: var(--tree-view-bg);
+}
+
+#threadPane[ac-colorpanebkgd][ac-bkgdasgradient][ac-bkgdasgradient-reverse] > #threadTree {
+    background-image: linear-gradient(to left, var(--ac-bkgd-color, var(--tree-view-bg)), transparent 100%);
 }
 
 /* Thread Pane - Font Style / Font Weight */

--- a/chrome/skin/accountcolors-composewindow.css
+++ b/chrome/skin/accountcolors-composewindow.css
@@ -215,9 +215,19 @@
     background-image: linear-gradient(to right, var(--ac-colortobkgd), transparent 100%);
 }
 
+:root[ac-colortobkgd-asgradient][ac-colortobkgd-asgradient-reverse] #addressingWidget textbox
+{
+    background-image: linear-gradient(to left, var(--ac-colortobkgd), transparent 100%);
+}
+
 :root[ac-colortobkgd-asgradient] #recipientsContainer .input-container
 {
     background-image: linear-gradient(to right, var(--ac-colortobkgd), transparent 100%);
+}
+
+:root[ac-colortobkgd-asgradient][ac-colortobkgd-asgradient-reverse] #recipientsContainer .input-container
+{
+    background-image: linear-gradient(to left, var(--ac-colortobkgd), transparent 100%);
 }
 
 /* Attachment font color */

--- a/defaults/preferences/accountcolors-prefs.js
+++ b/defaults/preferences/accountcolors-prefs.js
@@ -44,6 +44,7 @@ pref("extensions.accountcolors.folder-darkerbar", false);
 pref("extensions.accountcolors.folder-incspacing", false);
 pref("extensions.accountcolors.folder-hoverselect", true);
 pref("extensions.accountcolors.folder-colorbkgd-gradient", false);
+pref("extensions.accountcolors.folder-colorbkgd-gradient-reverse", false);
 pref("extensions.accountcolors.folder-colorbkgd-account-icon", true);
 pref("extensions.accountcolors.folder-colorbkgd-folder-icon", false);
 
@@ -74,6 +75,7 @@ pref("extensions.accountcolors.thread-darkerbar", false);
 pref("extensions.accountcolors.thread-incspacing", false);
 pref("extensions.accountcolors.thread-hoverselect", true);
 pref("extensions.accountcolors.thread-colorbkgd-gradient", false);
+pref("extensions.accountcolors.thread-colorbkgd-gradient-reverse", false);
 pref("extensions.accountcolors.thread-colorbkgd-row-label", false);
 pref("extensions.accountcolors.thread-row-label-position", 0);
 pref("extensions.accountcolors.thread-row-label-width", 2);
@@ -100,6 +102,7 @@ pref("extensions.accountcolors.message-whitehdrlabels", false);
 pref("extensions.accountcolors.message-hdraccount", false);
 pref("extensions.accountcolors.message-defaultbkgd", false);
 pref("extensions.accountcolors.message-colorbkgd-gradient", false);
+pref("extensions.accountcolors.message-colorbkgd-gradient-reverse", false);
 pref("extensions.accountcolors.message-colorbkgd-header-label", false);
 pref("extensions.accountcolors.message-header-label-width", 4);
 
@@ -132,6 +135,7 @@ pref("extensions.accountcolors.compose-darkfieldbkgd", false);
 pref("extensions.accountcolors.compose-defaultbkgd", false);
 pref("extensions.accountcolors.compose-hoverfrom", true);
 pref("extensions.accountcolors.compose-colorbkgd-gradient", false);
+pref("extensions.accountcolors.compose-colorbkgd-gradient-reverse", false);
 pref("extensions.accountcolors.compose-colorbkgd-idmenu-label", false);
 pref("extensions.accountcolors.compose-idmenu-label-width", 4);
 


### PR DESCRIPTION
Fixes #42

Add a direction dropdown (Left to Right / Right to Left) next to the "Color Background as Gradient" checkbox in all four panes (Folder, Thread, Message, Compose), allowing users to reverse the gradient effect.